### PR TITLE
feat: introduce scopes

### DIFF
--- a/src/main/bindings.ts
+++ b/src/main/bindings.ts
@@ -1,69 +1,18 @@
-import { Mesh } from './mesh';
-import { Constructor, ServiceConstructor } from './types';
+import { ServiceConstructor } from './types';
 
-export abstract class Binding<T> {
-    constructor(readonly mesh: Mesh, readonly key: string) {}
-    abstract get(): T;
-}
+export type Binding<T> = ConstantBinding<T> | ServiceBinding<T> | AliasBinding;
 
-export class ConstantBinding<T> extends Binding<T> {
+export type ConstantBinding<T> = {
+    type: 'constant';
     value: T;
+};
 
-    constructor(mesh: Mesh, key: string, value: T) {
-        super(mesh, key);
-        this.value = this.mesh.connect(value);
-    }
+export type ServiceBinding<T> = {
+    type: 'service';
+    class: ServiceConstructor<T>;
+};
 
-    get() {
-        return this.value;
-    }
-}
-
-export class ServiceBinding<T> extends Binding<T> {
-    ctor: ServiceConstructor<T>;
-    instance: T | undefined;
-
-    constructor(mesh: Mesh, key: string, ctor: ServiceConstructor<T>) {
-        super(mesh, key);
-        this.ctor = this.processClass(ctor);
-    }
-
-    get(): T {
-        if (!this.instance) {
-            const inst = new this.ctor();
-            this.instance = this.mesh.connect(inst);
-        }
-        return this.instance;
-    }
-
-    protected processClass(ctor: any) {
-        // A fake derived class is created with Mesh attached to its prototype.
-        // This allows accessing deps in constructor whilst preserving instanceof.
-        const derived = class extends ctor {};
-        Object.defineProperty(derived, 'name', { value: ctor.name });
-        this.mesh.injectRef(derived.prototype);
-        return derived;
-    }
-}
-
-export class ClassBinding<T extends Constructor<T>> extends Binding<T> {
-
-    constructor(mesh: Mesh, key: string, readonly ctor: T) {
-        super(mesh, key);
-    }
-
-    get(): T {
-        return this.ctor;
-    }
-}
-
-export class ProxyBinding<T> extends Binding<T> {
-
-    constructor(mesh: Mesh, key: string, readonly alias: string) {
-        super(mesh, key);
-    }
-
-    get(): T {
-        return this.mesh.resolve(this.alias);
-    }
+export type AliasBinding = {
+    type: 'alias';
+    key: string;
 }

--- a/src/main/errors.ts
+++ b/src/main/errors.ts
@@ -17,9 +17,9 @@ export class DepInstanceNotConnected extends BaseError {
     }
 }
 
-export class MeshServiceNotFound extends BaseError {
+export class MeshBindingNotFound extends BaseError {
     constructor(meshName: string, serviceKey: string) {
-        super(`Service "${serviceKey}" not found in Mesh "${meshName}"`);
+        super(`"${serviceKey}" not found in Mesh "${meshName}"`);
     }
 }
 

--- a/src/main/mesh.ts
+++ b/src/main/mesh.ts
@@ -1,82 +1,59 @@
-import { ClassBinding } from '.';
-import { Binding, ConstantBinding, ProxyBinding, ServiceBinding } from './bindings';
-import { MeshInvalidBinding, MeshServiceNotFound } from './errors';
-import { AbstractClass, Constructor, Middleware, ServiceConstructor, ServiceKey } from './types';
+import { Binding } from './bindings';
+import { MeshBindingNotFound } from './errors';
+import { Scope } from './scope';
+import { AbstractClass, Middleware, ServiceConstructor, ServiceKey } from './types';
+import { keyToString } from './util';
 
 export const MESH_REF = Symbol.for('MESH_REF');
 
 export class Mesh {
-    bindings: Map<string, Binding<any>> = new Map();
+    currentScope: Scope;
+    childScopes = new Map<string, Scope>();
+    instances = new Map<string, any>();
     middlewares: Middleware[] = [];
 
     constructor(
         public name: string = 'default',
         public parent: Mesh | undefined = undefined,
     ) {
-        this.constant('Mesh', this);
+        this.currentScope = new Scope(name);
+        this.currentScope.constant('Mesh', this);
     }
 
-    bind<T>(impl: ServiceConstructor<T>): Binding<T>;
-    bind<T>(key: AbstractClass<T> | string, impl: ServiceConstructor<T>): Binding<T>;
-    bind<T>(key: ServiceConstructor<T> | AbstractClass<T> | string, impl?: ServiceConstructor<T>): Binding<T> {
-        const k = keyToString(key);
-        if (typeof impl === 'function') {
-            return this._bindService(k, impl);
-        } else if (typeof key === 'function') {
-            return this._bindService(k, key);
-        }
-        throw new MeshInvalidBinding(String(key));
+    service<T>(impl: ServiceConstructor<T>): this;
+    service<T>(key: AbstractClass<T> | string, impl: ServiceConstructor<T>): this;
+    service<T>(key: ServiceConstructor<T> | AbstractClass<T> | string, impl?: ServiceConstructor<T>): this {
+        (this.currentScope.service as any)(key, impl);
+        return this;
     }
 
-    protected _bindService<T>(k: string, impl: ServiceConstructor<T>): Binding<T> {
-        const binding = new ServiceBinding<T>(this, k, impl);
-        this.bindings.set(k, binding);
-        return new ProxyBinding<T>(this, k, k);
+    constant<T>(key: ServiceKey<T>, value: T): this {
+        this.currentScope.constant(key, value);
+        return this;
     }
 
-    class<T extends Constructor<any>>(ctor: T): ClassBinding<T>;
-    class<T extends Constructor<any>>(key: AbstractClass<T> | string, ctor: T): Binding<T>;
-    class<T extends Constructor<any>>(key: T | AbstractClass<T> | string, ctor?: T) {
-        const k = keyToString(key);
-        if (typeof ctor === 'function') {
-            return this._bindClass(k, ctor);
-        } else if (typeof key === 'function') {
-            return this._bindClass(k, key);
-        }
-        throw new MeshInvalidBinding(String(key));
-    }
-
-    protected _bindClass<T extends Constructor<any>>(k: string, ctor: T): ClassBinding<T> {
-        const binding = new ClassBinding(this, k, ctor);
-        this.bindings.set(k, binding);
-        return binding;
-    }
-
-    constant<T>(key: ServiceKey<T>, value: T): Binding<T> {
-        const k = keyToString(key);
-        const binding = new ConstantBinding<T>(this, k, value);
-        this.bindings.set(k, binding);
-        return new ProxyBinding<T>(this, k, k);
-    }
-
-    alias<T>(key: AbstractClass<T> | string, referenceKey: AbstractClass<T> | string): Binding<T> {
-        const k = keyToString(key);
-        const refK = typeof referenceKey === 'string' ? referenceKey : referenceKey.name;
-        const binding = new ProxyBinding<T>(this, k, refK);
-        this.bindings.set(k, binding);
-        return binding;
+    alias<T>(key: AbstractClass<T> | string, referenceKey: AbstractClass<T> | string): this {
+        this.currentScope.alias(key, referenceKey);
+        return this;
     }
 
     resolve<T>(key: ServiceKey<T>): T {
         const k = keyToString(key);
-        const binding = this.bindings.get(k);
+        let instance = this.instances.get(k);
+        if (instance) {
+            return instance;
+        }
+        const binding = this.currentScope.bindings.get(k);
         if (binding) {
-            return binding.get();
+            instance = this.instantiate(binding);
+            instance = this.connect(instance);
+            this.instances.set(k, instance);
+            return instance;
         }
         if (this.parent) {
             return this.parent.resolve(key);
         }
-        throw new MeshServiceNotFound(this.name, k);
+        throw new MeshBindingNotFound(this.name, k);
     }
 
     connect<T>(value: T): T {
@@ -90,15 +67,53 @@ export class Mesh {
         return this;
     }
 
+    scope(scopeId: string): Scope {
+        let scope = this.childScopes.get(scopeId);
+        if (!scope) {
+            scope = new Scope(scopeId);
+            this.childScopes.set(scopeId, scope);
+        }
+        return scope;
+    }
+
+    createScope(scopeId: string, scopeName: string = scopeId): Mesh {
+        const childScope = this.childScopes.get(scopeId);
+        const newScope = new Scope(scopeName, childScope ?? []);
+        const mesh = new Mesh(scopeId, this);
+        mesh.currentScope = newScope;
+        return mesh;
+    }
+
+    protected instantiate<T>(binding: Binding<T>): T {
+        switch (binding.type) {
+            case 'alias':
+                return this.resolve(binding.key);
+            case 'service': {
+                // A fake derived class is created with Mesh attached to its prototype.
+                // This allows accessing deps in constructor whilst preserving instanceof.
+                const ctor = binding.class as any;
+                const derived = class extends ctor {};
+                Object.defineProperty(derived, 'name', { value: ctor.name });
+                this.injectRef(derived.prototype);
+                return new derived();
+            }
+            case 'constant':
+                return binding.value;
+        }
+    }
+
     protected applyMiddleware<T>(value: T): T {
         let res = value;
         for (const middleware of this.middlewares) {
             res = middleware(res);
         }
+        if (this.parent) {
+            res = this.parent.applyMiddleware(res);
+        }
         return res;
     }
 
-    injectRef(value: any) {
+    protected injectRef(value: any) {
         if (typeof value !== 'object') {
             return;
         }
@@ -108,8 +123,5 @@ export class Mesh {
             configurable: true,
         });
     }
-}
 
-function keyToString<T>(key: ServiceKey<T>) {
-    return typeof key === 'string' ? key : key.name;
 }

--- a/src/main/scope.ts
+++ b/src/main/scope.ts
@@ -1,0 +1,51 @@
+import { Binding } from './bindings';
+import { MeshInvalidBinding } from './errors';
+import { AbstractClass, ServiceConstructor, ServiceKey } from './types';
+import { keyToString } from './util';
+
+export const MESH_REF = Symbol.for('MESH_REF');
+
+export class Scope {
+    bindings = new Map<string, Binding<any>>();
+
+    constructor(
+        readonly name: string,
+        bindings: Iterable<[string, Binding<any>]> = [],
+    ) {
+        for (const [k, v] of bindings) {
+            this.bindings.set(k, v);
+        }
+    }
+
+    *[Symbol.iterator]() {
+        yield* this.bindings.entries();
+    }
+
+    service<T>(impl: ServiceConstructor<T>): this;
+    service<T>(key: AbstractClass<T> | string, impl: ServiceConstructor<T>): this;
+    service<T>(key: ServiceConstructor<T> | AbstractClass<T> | string, impl?: ServiceConstructor<T>): this {
+        const k = keyToString(key);
+        if (typeof impl === 'function') {
+            this.bindings.set(k, { type: 'service', class: impl });
+            return this;
+        } else if (typeof key === 'function') {
+            this.bindings.set(k, { type: 'service', class: key });
+            return this;
+        }
+        throw new MeshInvalidBinding(String(key));
+    }
+
+    constant<T>(key: ServiceKey<T>, value: T): this {
+        const k = keyToString(key);
+        this.bindings.set(k, { type: 'constant', value });
+        return this;
+    }
+
+    alias<T>(key: AbstractClass<T> | string, referenceKey: AbstractClass<T> | string) {
+        const k = keyToString(key);
+        const refK = keyToString(referenceKey);
+        this.bindings.set(k, { type: 'alias', key: refK });
+        return this;
+    }
+
+}

--- a/src/main/util.ts
+++ b/src/main/util.ts
@@ -1,0 +1,5 @@
+import { ServiceKey } from './types';
+
+export function keyToString<T>(key: ServiceKey<T>) {
+    return typeof key === 'string' ? key : key.name;
+}

--- a/src/test/specs/scope.test.ts
+++ b/src/test/specs/scope.test.ts
@@ -1,0 +1,63 @@
+import assert from 'assert';
+
+import { dep, Mesh } from '../../main';
+
+describe('Scopes', () => {
+
+    class SharedService {}
+
+    class ScopedService {
+        @dep({ key: 'SessionId' }) sessionId!: string;
+        @dep() shared!: SharedService;
+    }
+
+    class AnotherScopedService {
+        @dep({ key: 'SessionId' }) sessionId!: string;
+        @dep() scopedService!: ScopedService;
+    }
+
+    const mesh = new Mesh();
+    mesh.service(SharedService);
+    mesh.scope('session')
+        .service(ScopedService)
+        .service(AnotherScopedService);
+
+    it('creates a scoped mesh', () => {
+        const requestScope = mesh.createScope('session');
+        requestScope.constant('SessionId', '42');
+        const scopedService = requestScope.resolve(ScopedService);
+        assert.ok(scopedService instanceof ScopedService);
+        assert.strictEqual(scopedService.sessionId, '42');
+    });
+
+    it('dependencies of the same scope are equal', () => {
+        const requestScope = mesh.createScope('session');
+        requestScope.constant('SessionId', '42');
+        const scopedService = requestScope.resolve(ScopedService);
+        const anotherService = requestScope.resolve(AnotherScopedService);
+        assert.ok(scopedService === anotherService.scopedService);
+    });
+
+    it('scoped services in different scopes are not equal', () => {
+        const reqA = mesh.createScope('session')
+            .constant('SessionId', 'A');
+        const reqB = mesh.createScope('session')
+            .constant('SessionId', 'B');
+        const serviceA = reqA.resolve(ScopedService);
+        const serviceB = reqB.resolve(ScopedService);
+        assert.ok(serviceA !== serviceB);
+        assert.strictEqual(serviceA.sessionId, 'A');
+        assert.strictEqual(serviceB.sessionId, 'B');
+    });
+
+    it('shared services are still equal across scopes', () => {
+        const reqA = mesh.createScope('session')
+            .constant('SessionId', 'A');
+        const reqB = mesh.createScope('session')
+            .constant('SessionId', 'B');
+        const sharedServiceA = reqA.resolve(SharedService);
+        const sharedServiceB = reqB.resolve(SharedService);
+        assert.ok(sharedServiceA === sharedServiceB);
+    });
+
+});


### PR DESCRIPTION
This introduces the concept of scopes, which greatly improves the ergonomics in typical server applications.

Previously in order to achieve something like request/response lifecycle one would have to create a method to construct scoped mesh, e.g.

```ts
class SessionManager {
  @dep() mesh!: Mesh;

  createSession(sessionData: any) {
    const sessionMesh = new Mesh('session', this.mesh);
    sessionMesh.bind('SessionData', sessionData);
    // other deps
  }
  
}
```

The problem with such approach is: it's awkward to rebind scoped data (e.g. for testing or reusing). In order to do so one must re-implement SessionManager and copy parts of the mesh creation process.

With new API scoped dependencies are declared in one place (composition root).

```ts
mesh
  .service(Logger, GlobalLogger)
  .service(MyDatabase)
  .scope('session')
    .service(MySessionService);
```

